### PR TITLE
Check for number of trailing arguments in makefile

### DIFF
--- a/make.R
+++ b/make.R
@@ -6,7 +6,7 @@ Rcpp::compileAttributes()
 cat("*** Loading ... ***\n")
 devtools::document()
 
-if (nchar(args) >= 2 && substring(args, 1, 1) == "-") {
+if (length(args) > 0 && nchar(args) >= 2 && substring(args, 1, 1) == "-") {
   if (grepl("t", args)) {
     cat("*** Testing ... ***\n")
     devtools::test()


### PR DESCRIPTION
Avoids generating missing value error when no trailing arguments are passed.


Issue: if `./make` is run without any trailing arguments, `commandArgs(trailingOnly=TRUE)` yields a `character(0)`, which in turn causes the `nchar(args) >= 2 && substring(args, 1, 1) == "-"` comparison to yield an `NA`.

Reproducing example:

```
$ ./make
*** Compiling ... ***
*** Loading ... ***
ℹ Updating dspline documentation
ℹ Loading dspline
Error in if (nchar(args) >= 2 && substring(args, 1, 1) == "-") { :
  missing value where TRUE/FALSE needed
Execution halted
```

This change checks the length of the `args` vector and uses `&&` short circuiting to skip further evaluation if there are no trailing arguments.