### PR TITLE
Evaluate all entries for polynomial basis functions in `h_eval`

### DIFF
--- a/src/bases_weights.cpp
+++ b/src/bases_weights.cpp
@@ -3,63 +3,63 @@
 
 #include <Rcpp.h>
 #include "dspline.h"
-using namespace Rcpp; 
+using namespace Rcpp;
 
 double newton_poly(NumericVector z, double x, int n) {
-	double p = 1;
-	for (int i = 0; i < n; i++) {
-		p *= (x - z[i]);
-	}
-	return p; 
+  double p = 1;
+  for (int i = 0; i < n; i++) {
+    p *= (x - z[i]);
+  }
+  return p;
 }
 
 double dij(int k, NumericVector xd, int i, int j) {
-	if (i <= j && j <= i+k) {
-		double w = fact(k);
-		for (int l = i; l < i+k+1; l++) {
-			if (l != j) {
-				w /= xd[j] - xd[l];
-			}
-		}
-		return w;
-	}
-	else return 0;
+  if (i <= j && j <= i+k) {
+    double w = fact(k);
+    for (int l = i; l < i+k+1; l++) {
+      if (l != j) {
+        w /= xd[j] - xd[l];
+      }
+    }
+    return w;
+  }
+  else return 0;
 }
 
-double bij(int k, NumericVector xd, int i, int j) {		
-	if (i < k) {
-		if (j <= i) {
-			double w = fact(i);
-			for (int l = 0; l < i+1; l++) {
-				if (l != j) {
-					w /= xd[j] - xd[l];
-				}
-			}
-			return w;
-		}
-		else return 0;
-	}
-	else return dij(k, xd, i-k, j);
+double bij(int k, NumericVector xd, int i, int j) {
+  if (i < k) {
+    if (j <= i) {
+      double w = fact(i);
+      for (int l = 0; l < i+1; l++) {
+        if (l != j) {
+          w /= xd[j] - xd[l];
+        }
+      }
+      return w;
+    }
+    else return 0;
+  }
+  else return dij(k, xd, i-k, j);
 }
 
 double hxj(int k, NumericVector xd, double x, int j) {
-	if (j <= k) {
-		double h = 1; 
-		for (int l = 0; l < j; l++) {
-			h *= (x - xd[l]) / (l+1);
-		}
-		return h;
-	}
-	else {
-		if (x <= xd[j-1]) return 0;
-		else {
-			double h = 1; 
-			for (int l = 0; l < k; l++) {
-				h *= (x - xd[j-k+l]) / (l+1);
-			}
-			return h;
-		}
-	}
+  if (j <= k) {
+    double h = 1;
+    for (int l = 0; l < j; l++) {
+      h *= (x - xd[l]) / (l+1);
+    }
+    return h;
+  }
+  else {
+    if (x <= xd[j-1]) return 0;
+    else {
+      double h = 1;
+      for (int l = 0; l < k; l++) {
+        h *= (x - xd[j-k+l]) / (l+1);
+      }
+      return h;
+    }
+  }
 }
 
 /******************************************************************************/
@@ -73,179 +73,179 @@ using Eigen::SparseMatrix;
 using Eigen::SparseQR;
 using Eigen::VectorXd;
 
-void nj(int k, NumericVector xd, IntegerVector knot_idx, int j_col, IntegerVector i_vec, IntegerVector j_vec, NumericVector x_vec, int& l) { 
-	int n_row = xd.size() - k - 1;
-	int t = knot_idx[j_col]; // Last knot
-	VectorXd x; 
+void nj(int k, NumericVector xd, IntegerVector knot_idx, int j_col, IntegerVector i_vec, IntegerVector j_vec, NumericVector x_vec, int& l) {
+  int n_row = xd.size() - k - 1;
+  int t = knot_idx[j_col]; // Last knot
+  VectorXd x;
 
-	// First k+1 basis vectors
-	if (j_col < k+1) {
-		// Add entry where the basis vector equals 1
-		i_vec[l] = j_col;
-		j_vec[l] = j_col;
-		x_vec[l] = 1;
-		l++;
+  // First k+1 basis vectors
+  if (j_col < k+1) {
+    // Add entry where the basis vector equals 1
+    i_vec[l] = j_col;
+    j_vec[l] = j_col;
+    x_vec[l] = 1;
+    l++;
 
-		// Add remaining entries only if t-k >= j_col+1
-		if (t-k >= j_col+1) {
-			// Compute row indices i such that i+k is NOT one of first j_col-1 knots
-			IntegerVector I0 = Range(k, t-1);
-			IntegerVector I (t-k-j_col);
-			std::set_difference(I0.begin(), I0.end(), knot_idx.begin(), knot_idx.begin()+j_col, I.begin());
-			for (int p = 0; p < t-k-j_col; p++) I[p] -= k;
+    // Add remaining entries only if t-k >= j_col+1
+    if (t-k >= j_col+1) {
+      // Compute row indices i such that i+k is NOT one of first j_col-1 knots
+      IntegerVector I0 = Range(k, t-1);
+      IntegerVector I (t-k-j_col);
+      std::set_difference(I0.begin(), I0.end(), knot_idx.begin(), knot_idx.begin()+j_col, I.begin());
+      for (int p = 0; p < t-k-j_col; p++) I[p] -= k;
 
-			// Compute column indices that correspond to unknown indices
-			IntegerVector J = Range(j_col+1, t-k);
+      // Compute column indices that correspond to unknown indices
+      IntegerVector J = Range(j_col+1, t-k);
 
-			// Step 1a: form appropriate matrix D
-			std::vector<T> d_list;
-			int q_start = 0, q_end; 
-			d_list.reserve((t-k-j_col) * (k+2));
-			for (int p = 0; p < t-k-j_col; p++) {
-				// We know D is banded, find relevant start/end points
-				while(J[q_start] < I[p]) q_start++;
-				q_end = std::min(q_start+k+1, t-k-j_col-1);
-				for (int q = q_start; q <= q_end; q++) {
-					d_list.push_back(T(p, q, dij(k+1, xd, I[p], J[q])));
-				}
-			}
-			SparseMatrix<double> D(t-k-j_col, t-k-j_col); 
-			D.setFromTriplets(d_list.begin(), d_list.end());
-			
-			// Step 1b: form appropriate vector b
-			VectorXd b (t-k-j_col); 
-			for (int p = 0; p < t-k-j_col; p++) {
-				b[p] = -1.0 * dij(k+1, xd, I[p], j_col);
-			}
-			
-			// Step 2: solve linear system Dx = b
-			SparseQR<SparseMatrix<double>, Ord> qr;
-			qr.compute(D); 
-			x = qr.solve(b);
+      // Step 1a: form appropriate matrix D
+      std::vector<T> d_list;
+      int q_start = 0, q_end;
+      d_list.reserve((t-k-j_col) * (k+2));
+      for (int p = 0; p < t-k-j_col; p++) {
+        // We know D is banded, find relevant start/end points
+        while(J[q_start] < I[p]) q_start++;
+        q_end = std::min(q_start+k+1, t-k-j_col-1);
+        for (int q = q_start; q <= q_end; q++) {
+          d_list.push_back(T(p, q, dij(k+1, xd, I[p], J[q])));
+        }
+      }
+      SparseMatrix<double> D(t-k-j_col, t-k-j_col);
+      D.setFromTriplets(d_list.begin(), d_list.end());
 
-			// Step 3: record vector x in the list
-			for (int q = 0; q < t-k-j_col; q++) {
-				if (J[q] < n_row) {
-					i_vec[l] = J[q];
-					j_vec[l] = j_col;
-					x_vec[l] = x[q];
-					l++;
-				}
-			}
-		}
-	}
+      // Step 1b: form appropriate vector b
+      VectorXd b (t-k-j_col);
+      for (int p = 0; p < t-k-j_col; p++) {
+        b[p] = -1.0 * dij(k+1, xd, I[p], j_col);
+      }
 
-	// Last r-k-1 basis vectors
-	else {
-		// First and second knots
-		int t1 = knot_idx[j_col-k-1];
-		int t2 = knot_idx[j_col-k];
+      // Step 2: solve linear system Dx = b
+      SparseQR<SparseMatrix<double>, Ord> qr;
+      qr.compute(D);
+      x = qr.solve(b);
 
-		// Add entry where basis vector equals 1
-		i_vec[l] = t2;
-		j_vec[l] = j_col;
-		x_vec[l] = 1;
-		l++;
+      // Step 3: record vector x in the list
+      for (int q = 0; q < t-k-j_col; q++) {
+        if (J[q] < n_row) {
+          i_vec[l] = J[q];
+          j_vec[l] = j_col;
+          x_vec[l] = x[q];
+          l++;
+        }
+      }
+    }
+  }
 
-		// Add more entries between first and second knot
-		if (t2-1 >= t1+1) {
-			// Compute row indices and columns indices for the appropriate divided 
-			// differences and unknown indices between first and second knot
-			IntegerVector I = Range(t1-k+1, t2-k-1);
-			IntegerVector J = Range(t1+1, t2-1);
+  // Last r-k-1 basis vectors
+  else {
+    // First and second knots
+    int t1 = knot_idx[j_col-k-1];
+    int t2 = knot_idx[j_col-k];
 
-			// Step 1a: form appropriate matrix D
-			std::vector<T> d_list;
-			int q_start = 0, q_end; 
-			d_list.reserve((t2-t1-1) * (k+2));
-			for (int p = 0; p < t2-t1-1; p++) {
-				q_start = std::max(p-k, 0);
-				q_end = std::min(p+1, t2-t1-2);
-				for (int q = q_start; q <= q_end; q++) {
-					d_list.push_back(T(p, q, dij(k+1, xd, I[p], J[q])));
-				}
-			}
-			SparseMatrix<double> D(t2-t1-1, t2-t1-1); 
-			D.setFromTriplets(d_list.begin(), d_list.end());
-			
-			// Step 1b: form appropriate vector b
-			VectorXd b (t2-t1-1); 
-			for (int p = 0; p < t2-t1-1; p++) {
-				b[p] = -1.0 * dij(k+1, xd, I[p], t2);
-			}
-			
-			// Step 2: solve linear system Dx = b
-			SparseQR<SparseMatrix<double>, Ord> qr;
-			qr.compute(D); 
-			x = qr.solve(b);
+    // Add entry where basis vector equals 1
+    i_vec[l] = t2;
+    j_vec[l] = j_col;
+    x_vec[l] = 1;
+    l++;
 
-			// Step 3: record vector x in the list
-			for (int q = 0; q < t2-t1-1; q++) {
-				if (J[q] < n_row) {
-					i_vec[l] = J[q];
-					j_vec[l] = j_col;
-					x_vec[l] = x[q];
-					l++;
-				}
-			}
-		}
+    // Add more entries between first and second knot
+    if (t2-1 >= t1+1) {
+      // Compute row indices and columns indices for the appropriate divided
+      // differences and unknown indices between first and second knot
+      IntegerVector I = Range(t1-k+1, t2-k-1);
+      IntegerVector J = Range(t1+1, t2-1);
 
-		// Add more entries between second and last knot
-		if (t-k >= t2+1) {
-			// Compute row indices i such that i+k is NOT one of the local knots
-			IntegerVector I0 = Range(t2+1, t-1);
-			IntegerVector I (t-k-t2);
-			std::set_difference(I0.begin(), I0.end(), knot_idx.begin()+j_col-k+1, knot_idx.begin()+j_col, I.begin());
-			for (int p = 0; p < t-k-t2; p++) I[p] -= k;
+      // Step 1a: form appropriate matrix D
+      std::vector<T> d_list;
+      int q_start = 0, q_end;
+      d_list.reserve((t2-t1-1) * (k+2));
+      for (int p = 0; p < t2-t1-1; p++) {
+        q_start = std::max(p-k, 0);
+        q_end = std::min(p+1, t2-t1-2);
+        for (int q = q_start; q <= q_end; q++) {
+          d_list.push_back(T(p, q, dij(k+1, xd, I[p], J[q])));
+        }
+      }
+      SparseMatrix<double> D(t2-t1-1, t2-t1-1);
+      D.setFromTriplets(d_list.begin(), d_list.end());
 
-			// Compute column indices that correspond to the unknown indices between
-			// second and last knot
-			IntegerVector J = Range(t2+1, t-k);
+      // Step 1b: form appropriate vector b
+      VectorXd b (t2-t1-1);
+      for (int p = 0; p < t2-t1-1; p++) {
+        b[p] = -1.0 * dij(k+1, xd, I[p], t2);
+      }
 
-			// Step 1a: form appropriate matrix D
-			std::vector<T> d_list;
-			int q_start = 0, q_end; 
-			d_list.reserve((t-k-t2) * (k+2));
-			for (int p = 0; p < t-k-t2; p++) {
-				// We know D is banded, find relevant start/end points
-				while(J[q_start] < I[p]) q_start++;
-				q_end = std::min(q_start+k+1, t-k-t2-1);
-				for (int q = q_start; q <= q_end; q++) {
-					d_list.push_back(T(p, q, dij(k+1, xd, I[p], J[q])));
-				}
-			}
-			SparseMatrix<double> D(t-k-t2, t-k-t2); 
-			D.setFromTriplets(d_list.begin(), d_list.end());
-			
-			// Step 1b: form appropriate vector b
-			VectorXd b (t-k-t2); 
-			for (int p = 0; p < t-k-t2; p++) {
-				b[p] = -1.0 * dij(k+1, xd, I[p], t2);
+      // Step 2: solve linear system Dx = b
+      SparseQR<SparseMatrix<double>, Ord> qr;
+      qr.compute(D);
+      x = qr.solve(b);
 
-				// Contributions between first and second knot
-				if (t2-t1-1 > 0) {
-					for (int q = 0; q < t2-t1-1; q++) {
-						b[p] += -x[q] * dij(k+1, xd, I[p], t1+1+q);
-					}
-				}
-			}
-			
-			// Step 2: solve linear system Dx = b
-			SparseQR<SparseMatrix<double>, Ord> qr;
-			qr.compute(D); 
-			x = qr.solve(b);
+      // Step 3: record vector x in the list
+      for (int q = 0; q < t2-t1-1; q++) {
+        if (J[q] < n_row) {
+          i_vec[l] = J[q];
+          j_vec[l] = j_col;
+          x_vec[l] = x[q];
+          l++;
+        }
+      }
+    }
 
-			// Step 3: record vector x in the list
-			for (int q = 0; q < t-k-t2; q++) {
-				if (J[q] < n_row) {
-					i_vec[l] = J[q];
-					j_vec[l] = j_col;
-					x_vec[l] = x[q];
-					l++;
-				}
-			}
-		}
-	}
+    // Add more entries between second and last knot
+    if (t-k >= t2+1) {
+      // Compute row indices i such that i+k is NOT one of the local knots
+      IntegerVector I0 = Range(t2+1, t-1);
+      IntegerVector I (t-k-t2);
+      std::set_difference(I0.begin(), I0.end(), knot_idx.begin()+j_col-k+1, knot_idx.begin()+j_col, I.begin());
+      for (int p = 0; p < t-k-t2; p++) I[p] -= k;
 
-	return; 
+      // Compute column indices that correspond to the unknown indices between
+      // second and last knot
+      IntegerVector J = Range(t2+1, t-k);
+
+      // Step 1a: form appropriate matrix D
+      std::vector<T> d_list;
+      int q_start = 0, q_end;
+      d_list.reserve((t-k-t2) * (k+2));
+      for (int p = 0; p < t-k-t2; p++) {
+        // We know D is banded, find relevant start/end points
+        while(J[q_start] < I[p]) q_start++;
+        q_end = std::min(q_start+k+1, t-k-t2-1);
+        for (int q = q_start; q <= q_end; q++) {
+          d_list.push_back(T(p, q, dij(k+1, xd, I[p], J[q])));
+        }
+      }
+      SparseMatrix<double> D(t-k-t2, t-k-t2);
+      D.setFromTriplets(d_list.begin(), d_list.end());
+
+      // Step 1b: form appropriate vector b
+      VectorXd b (t-k-t2);
+      for (int p = 0; p < t-k-t2; p++) {
+        b[p] = -1.0 * dij(k+1, xd, I[p], t2);
+
+        // Contributions between first and second knot
+        if (t2-t1-1 > 0) {
+          for (int q = 0; q < t2-t1-1; q++) {
+            b[p] += -x[q] * dij(k+1, xd, I[p], t1+1+q);
+          }
+        }
+      }
+
+      // Step 2: solve linear system Dx = b
+      SparseQR<SparseMatrix<double>, Ord> qr;
+      qr.compute(D);
+      x = qr.solve(b);
+
+      // Step 3: record vector x in the list
+      for (int q = 0; q < t-k-t2; q++) {
+        if (J[q] < n_row) {
+          i_vec[l] = J[q];
+          j_vec[l] = j_col;
+          x_vec[l] = x[q];
+          l++;
+        }
+      }
+    }
+  }
+
+  return;
 }

--- a/src/discrete_calculus.cpp
+++ b/src/discrete_calculus.cpp
@@ -1,93 +1,93 @@
 /******************************************************************************/
-// Divided differences, discrete derivatives, and discrete integrals 
+// Divided differences, discrete derivatives, and discrete integrals
 
 #include <Rcpp.h>
 #include "dspline.h"
-using namespace Rcpp; 
+using namespace Rcpp;
 
 void dot_divided_diff(NumericVector f, NumericVector z, int n) {
   for (int i = 0; i < n; i++) {
-		for (int j = n-1; j >= i+1; j--) {
-			f[j] = (f[j] - f[j-1]) / (z[j] - z[j-i-1]);
-		}
-	}
-	return;
+    for (int j = n-1; j >= i+1; j--) {
+      f[j] = (f[j] - f[j-1]) / (z[j] - z[j-i-1]);
+    }
+  }
+  return;
 }
 
 double divided_diff(NumericVector f, NumericVector z, int n) {
-	NumericVector f_copy = clone(f);
-	dot_divided_diff(f_copy, z, n);
-	return f_copy[n-1];
+  NumericVector f_copy = clone(f);
+  dot_divided_diff(f_copy, z, n);
+  return f_copy[n-1];
 }
 
 // [[Rcpp::export]]
 void rcpp_dot_divided_diff(NumericVector f, NumericVector z) {
-	return dot_divided_diff(f, z, f.size());
+  return dot_divided_diff(f, z, f.size());
 }
 
 // [[Rcpp::export]]
 double rcpp_divided_diff(NumericVector f, NumericVector z) {
-	return divided_diff(f, z, f.size());
+  return divided_diff(f, z, f.size());
 }
 
 // [[Rcpp::export]]
-NumericVector rcpp_discrete_deriv(NumericVector f, int k, NumericVector xd, NumericVector x) {   
-	// Take care of trivial case first
-	int nx = x.size();
-	if (k == 0) return f[Range(f.size()-nx, f.size()-1)];
+NumericVector rcpp_discrete_deriv(NumericVector f, int k, NumericVector xd, NumericVector x) {
+  // Take care of trivial case first
+  int nx = x.size();
+  if (k == 0) return f[Range(f.size()-nx, f.size()-1)];
 
-	NumericVector a (nx);
-	for (int l = 0; l < nx; l++) {
-		// Find the largest i such that x_i < x
-		int i = std::lower_bound(xd.begin(), xd.end(), x[l]) - xd.begin() - 1;
+  NumericVector a (nx);
+  for (int l = 0; l < nx; l++) {
+    // Find the largest i such that x_i < x
+    int i = std::lower_bound(xd.begin(), xd.end(), x[l]) - xd.begin() - 1;
 
-		// If x <= x_1, then return f(x)
-		if (i < 0) a[l] = f[f.size()-nx+l];
-	
-		// Else assemble centers, evaluations, compute scaled divided difference 
-		else {
-			int j = std::min(k-1, i);
-			NumericVector xd_sub = xd[Range(i-j, i)];
-			NumericVector f_sub = f[Range(i-j, i)];
-			xd_sub.push_back(x[l]);
-			f_sub.push_back(f[f.size()-nx+l]);
-			a[l] = rcpp_divided_diff(f_sub, xd_sub) * fact(j+1);
-		}
-	}
-	return a;
+    // If x <= x_1, then return f(x)
+    if (i < 0) a[l] = f[f.size()-nx+l];
+
+    // Else assemble centers, evaluations, compute scaled divided difference
+    else {
+      int j = std::min(k-1, i);
+      NumericVector xd_sub = xd[Range(i-j, i)];
+      NumericVector f_sub = f[Range(i-j, i)];
+      xd_sub.push_back(x[l]);
+      f_sub.push_back(f[f.size()-nx+l]);
+      a[l] = rcpp_divided_diff(f_sub, xd_sub) * fact(j+1);
+    }
+  }
+  return a;
 }
 
 // [[Rcpp::export]]
-NumericVector rcpp_discrete_integ(NumericVector f, int k, NumericVector xd, NumericVector x) {   
-	// Take care of trivial case first
-	int nx = x.size();
-	if (k == 0) return f[Range(f.size()-nx, f.size()-1)];
-	
-	NumericVector a (nx);
-	for (int l = 0; l < nx; l++) {
-		// Find the largest i such that x_i < x
-		int i = std::lower_bound(xd.begin(), xd.end(), x[l]) - xd.begin() - 1;
+NumericVector rcpp_discrete_integ(NumericVector f, int k, NumericVector xd, NumericVector x) {
+  // Take care of trivial case first
+  int nx = x.size();
+  if (k == 0) return f[Range(f.size()-nx, f.size()-1)];
 
-		// If x <= x_1, then return f(x)
-		if (i < 0) a[l] = f[f.size()-nx+l];
-	
-		// Else use linear combination form in (48) of Tibshirani (2020)
-		else {
-			double b, sum = 0;
-			// Summands for x_1, ..., x_i
-			for (int j = 0; j <= i; j++) {
-				b = hxj(k-1, xd, x[l], j);
-				if (j >= k) b *= (xd[j] - xd[j-k]) / k;
-				b *= f[j];
-				sum += b;
-			}
-			// Summand for x
-			b = hxj(k-1, xd, x[l], i+1);
-			if (i+1 >= k) b *= (x[l] - xd[i+1-k]) / k;
-			b *= f[f.size()-nx+l];
-			sum += b;
-			a[l] = sum;
-		}
-	}
-	return a;
+  NumericVector a (nx);
+  for (int l = 0; l < nx; l++) {
+    // Find the largest i such that x_i < x
+    int i = std::lower_bound(xd.begin(), xd.end(), x[l]) - xd.begin() - 1;
+
+    // If x <= x_1, then return f(x)
+    if (i < 0) a[l] = f[f.size()-nx+l];
+
+    // Else use linear combination form in (48) of Tibshirani (2020)
+    else {
+      double b, sum = 0;
+      // Summands for x_1, ..., x_i
+      for (int j = 0; j <= i; j++) {
+        b = hxj(k-1, xd, x[l], j);
+        if (j >= k) b *= (xd[j] - xd[j-k]) / k;
+        b *= f[j];
+        sum += b;
+      }
+      // Summand for x
+      b = hxj(k-1, xd, x[l], i+1);
+      if (i+1 >= k) b *= (x[l] - xd[i+1-k]) / k;
+      b *= f[f.size()-nx+l];
+      sum += b;
+      a[l] = sum;
+    }
+  }
+  return a;
 }

--- a/src/interpolation.cpp
+++ b/src/interpolation.cpp
@@ -3,98 +3,98 @@
 
 #include <Rcpp.h>
 #include "dspline.h"
-using namespace Rcpp; 
+using namespace Rcpp;
 
 // [[Rcpp::export]]
 NumericVector rcpp_newton_interp(NumericVector v, NumericVector z, NumericVector x) {
-	NumericVector p (x.size()); 
-	for (int i = 0; i < x.size(); i++) {
-		p[i] = 0; 
-		for (int l = 0; l < z.size(); l++) {
-			p[i] += divided_diff(v, z, l+1) * newton_poly(z, x[i], l);
-		}
-	}
-	return p; 
+  NumericVector p (x.size());
+  for (int i = 0; i < x.size(); i++) {
+    p[i] = 0;
+    for (int l = 0; l < z.size(); l++) {
+      p[i] += divided_diff(v, z, l+1) * newton_poly(z, x[i], l);
+    }
+  }
+  return p;
 }
 
 // [[Rcpp::export]]
-NumericVector rcpp_dspline_interp(NumericVector v, int k, NumericVector xd, NumericVector x, bool implicit) { 
-	int nx = x.size(); 
-	NumericVector f (nx); 
+NumericVector rcpp_dspline_interp(NumericVector v, int k, NumericVector xd, NumericVector x, bool implicit) {
+  int nx = x.size();
+  NumericVector f (nx);
 
-	// Falling factorial interpolation 
-	if (!implicit) {
-		// Locate each x point among knot points only  
-		IntegerVector J (nx); 
-		for (int l = 0 ; l < nx; l++) {
-			// Find the smallest i such that x_i \geq x 
-			J[l] = std::lower_bound(xd.begin() + k + 1, xd.end(), x[l]) - xd.begin();
-			J[l] = std::min(J[l], (int) xd.size()-1);
-		}
+  // Falling factorial interpolation
+  if (!implicit) {
+    // Locate each x point among knot points only
+    IntegerVector J (nx);
+    for (int l = 0 ; l < nx; l++) {
+      // Find the smallest i such that x_i \geq x
+      J[l] = std::lower_bound(xd.begin() + k + 1, xd.end(), x[l]) - xd.begin();
+      J[l] = std::min(J[l], (int) xd.size()-1);
+    }
 
-		// Compute basis coefficients a = B^{k+1} Z^{k+1} v
-		NumericVector a = rcpp_b_mat_mult(v, k+1, xd, 1, 0, 0);
+    // Compute basis coefficients a = B^{k+1} Z^{k+1} v
+    NumericVector a = rcpp_b_mat_mult(v, k+1, xd, 1, 0, 0);
 
-		// Multiply by falling factorial basis H^{k+1}_x at x
-		for (int i = 0; i < nx; i++) {
-			f[i] = 0; 
-			// Pure polynomials
-			for (int j = 0; j < k+1; j++) {
-				f[i] += hxj(k, xd, x[i], j) * a[j];
-			}
-			// Piecewise polynomials
-			for (int j = k+1; j <= J[i]; j++) {
-				if (a[j] != 0) {
-					f[i] += hxj(k, xd, x[i], j) * a[j];
-				}
-			}
-		}
-	}
+    // Multiply by falling factorial basis H^{k+1}_x at x
+    for (int i = 0; i < nx; i++) {
+      f[i] = 0;
+      // Pure polynomials
+      for (int j = 0; j < k+1; j++) {
+        f[i] += hxj(k, xd, x[i], j) * a[j];
+      }
+      // Piecewise polynomials
+      for (int j = k+1; j <= J[i]; j++) {
+        if (a[j] != 0) {
+          f[i] += hxj(k, xd, x[i], j) * a[j];
+        }
+      }
+    }
+  }
 
-	// Implicit form interpolation
-	else {	
-		// Locate each x point among all design points 
-		IntegerVector J (nx); 
-		for (int l = 0 ; l < nx; l++) {
-			// Find the smallest i such that x_i \geq x 
-			J[l] = std::lower_bound(xd.begin(), xd.end(), x[l]) - xd.begin();
-			J[l] = std::min(J[l], (int) xd.size()-1);
-		}
+  // Implicit form interpolation
+  else {
+    // Locate each x point among all design points
+    IntegerVector J (nx);
+    for (int l = 0 ; l < nx; l++) {
+      // Find the smallest i such that x_i \geq x
+      J[l] = std::lower_bound(xd.begin(), xd.end(), x[l]) - xd.begin();
+      J[l] = std::min(J[l], (int) xd.size()-1);
+    }
 
-		double s, w;
-		int offset; 
+    double s, w;
+    int offset;
 
-		for (int i = 0; i < nx; i++) {
-			// Trivial case where x is one of the design points
-			if (xd[J[i]] == x[i]) {
-				f[i] = v[i]; 
-				continue; 
-			}
-			
-			// If J[i] < k, solve for f(x) in f[xd[0], ..., xd[k], x] = 0
-			// Else, solve for f(x) in f[xd[J[i]-k], ..., xd[J[i]], x] = 0
-			if (J[i] < k) offset = 0;
-			else offset = J[i]-k;
+    for (int i = 0; i < nx; i++) {
+      // Trivial case where x is one of the design points
+      if (xd[J[i]] == x[i]) {
+        f[i] = v[i];
+        continue;
+      }
 
-			s = 0; 
-			for (int j = 0; j < k+1; j++) {
-				w = 1;
-				for (int l = 0; l < k+1; l++) {
-					if (l != j) {
-						w /= xd[offset + j] - xd[offset + l];
-					}
-				}
-				w /= xd[offset + j] - x[i]; 
-				s -= w * v[offset + j];
-			}
+      // If J[i] < k, solve for f(x) in f[xd[0], ..., xd[k], x] = 0
+      // Else, solve for f(x) in f[xd[J[i]-k], ..., xd[J[i]], x] = 0
+      if (J[i] < k) offset = 0;
+      else offset = J[i]-k;
 
-			w = 1;
-			for (int l = 0; l < k+1; l++) {
-				w /= x[i] - xd[offset + l];
-			}
-			f[i] = s / w;
-		}
-	}
+      s = 0;
+      for (int j = 0; j < k+1; j++) {
+        w = 1;
+        for (int l = 0; l < k+1; l++) {
+          if (l != j) {
+            w /= xd[offset + j] - xd[offset + l];
+          }
+        }
+        w /= xd[offset + j] - x[i];
+        s -= w * v[offset + j];
+      }
 
-	return f;
+      w = 1;
+      for (int l = 0; l < k+1; l++) {
+        w /= x[i] - xd[offset + l];
+      }
+      f[i] = s / w;
+    }
+  }
+
+  return f;
 }

--- a/src/matrix_construction.cpp
+++ b/src/matrix_construction.cpp
@@ -119,8 +119,13 @@ List rcpp_h_eval(int k, NumericVector xd, NumericVector x, IntegerVector col_idx
   int n_row = x.size(), n_col = col_idx.size(), N = n_row * n_col;
   IntegerVector I (n_col);
   for (int j = 0; j < n_col; j++) {
-    // Find the index of smallest nonzero query evaluation for h_j
-    I[j] = std::upper_bound(x.begin(), x.end(), xd[col_idx[j]-1]) - x.begin();
+    if (col_idx[j] < k+1) {
+      // Evaluate all entries for polynomial basis functions
+      I[j] = 0;
+    } else {
+      // Find the index of smallest nonzero query evaluation for h_j
+      I[j] = std::upper_bound(x.begin(), x.end(), xd[col_idx[j]-1]) - x.begin();
+    }
     N -= I[j];
   }
 

--- a/src/matrix_construction.cpp
+++ b/src/matrix_construction.cpp
@@ -3,109 +3,109 @@
 
 #include <Rcpp.h>
 #include "dspline.h"
-using namespace Rcpp; 
+using namespace Rcpp;
 
 // [[Rcpp::export]]
 List rcpp_b_mat(int k, NumericVector xd, bool tf_weighting, IntegerVector row_idx, bool d_only) {
-	// Compute number of nonzero elements for D. We do so by computing nonzeros
-	// per row (discrete derivative vector). Start by guessing k+1 nonzeros per
-	// row, then if needed, adjust for rows that give lower order derivatives
-	int	n_row = row_idx.size(), N = n_row * (k+1);
-	if (!d_only) {
-		for (int i = 0; i < n_row; i++) { 
-			if (row_idx[i] < k) N += (row_idx[i]+1 - k-1);
-		}
-	}
+  // Compute number of nonzero elements for D. We do so by computing nonzeros
+  // per row (discrete derivative vector). Start by guessing k+1 nonzeros per
+  // row, then if needed, adjust for rows that give lower order derivatives
+  int  n_row = row_idx.size(), N = n_row * (k+1);
+  if (!d_only) {
+    for (int i = 0; i < n_row; i++) {
+      if (row_idx[i] < k) N += (row_idx[i]+1 - k-1);
+    }
+  }
 
-	// Now construct D in sparse triplet format
-	IntegerVector i_vec (N);
-	IntegerVector j_vec (N);
-	NumericVector x_vec (N);
-	int l = 0, j_start, j_end;
-	for (int i = 0; i < n_row; i++) {
-		j_start = std::max(row_idx[i] - (!d_only * k), 0);
-		j_end = row_idx[i] + (d_only * k);
-		for (int j = j_start; j <= j_end; j++) {
-			i_vec[l] = i;
-			j_vec[l] = j;
-			if (!d_only) x_vec[l] = bij(k, xd, row_idx[i], j);
-			else x_vec[l] = dij(k, xd, row_idx[i], j);
+  // Now construct D in sparse triplet format
+  IntegerVector i_vec (N);
+  IntegerVector j_vec (N);
+  NumericVector x_vec (N);
+  int l = 0, j_start, j_end;
+  for (int i = 0; i < n_row; i++) {
+    j_start = std::max(row_idx[i] - (!d_only * k), 0);
+    j_end = row_idx[i] + (d_only * k);
+    for (int j = j_start; j <= j_end; j++) {
+      i_vec[l] = i;
+      j_vec[l] = j;
+      if (!d_only) x_vec[l] = bij(k, xd, row_idx[i], j);
+      else x_vec[l] = dij(k, xd, row_idx[i], j);
 
-			// Trend filtering weighting (only applies to k >= 0)
-			if (tf_weighting && k > 0) {
-				if (!d_only && row_idx[i] >= k) {
-					x_vec[l] *= (xd[row_idx[i]] - xd[row_idx[i]-k]) / k; 
-				}
-				else if (d_only) {
-					x_vec[l] *= (xd[row_idx[i]+k] - xd[row_idx[i]]) / k; 
-				}
-			}
-			l++;
-		}
-	}
+      // Trend filtering weighting (only applies to k >= 0)
+      if (tf_weighting && k > 0) {
+        if (!d_only && row_idx[i] >= k) {
+          x_vec[l] *= (xd[row_idx[i]] - xd[row_idx[i]-k]) / k;
+        }
+        else if (d_only) {
+          x_vec[l] *= (xd[row_idx[i]+k] - xd[row_idx[i]]) / k;
+        }
+      }
+      l++;
+    }
+  }
 
-	return List::create(Named("i") = i_vec, Named("j") = j_vec, Named("x") = x_vec);
+  return List::create(Named("i") = i_vec, Named("j") = j_vec, Named("x") = x_vec);
 }
 
 // [[Rcpp::export]]
 List rcpp_h_mat(int k, NumericVector xd, bool di_weighting, IntegerVector col_idx) {
-	// Compute number of nonzero elements for H. We do so by computing nonzeros
-	// per column (falling factorial basis vector)
-	int n_row = xd.size(), n_col = col_idx.size(), N = n_col * n_row;
-	for (int j = 0; j < n_col; j++) N -= col_idx[j];
+  // Compute number of nonzero elements for H. We do so by computing nonzeros
+  // per column (falling factorial basis vector)
+  int n_row = xd.size(), n_col = col_idx.size(), N = n_col * n_row;
+  for (int j = 0; j < n_col; j++) N -= col_idx[j];
 
-	// Now construct H in sparse triplet format
-	IntegerVector i_vec (N);
-	IntegerVector j_vec (N);
-	NumericVector x_vec (N);
-	int l = 0;
-	for (int j = 0; j < n_col; j++) {
-		for (int i = col_idx[j]; i < n_row; i++) {
-			i_vec[l] = i;
-			j_vec[l] = j;
-			x_vec[l] = hxj(k, xd, xd[i], col_idx[j]);
+  // Now construct H in sparse triplet format
+  IntegerVector i_vec (N);
+  IntegerVector j_vec (N);
+  NumericVector x_vec (N);
+  int l = 0;
+  for (int j = 0; j < n_col; j++) {
+    for (int i = col_idx[j]; i < n_row; i++) {
+      i_vec[l] = i;
+      j_vec[l] = j;
+      x_vec[l] = hxj(k, xd, xd[i], col_idx[j]);
 
-			// Discrete integration weighting
-			if (di_weighting && col_idx[j] >= k+1) {
-				x_vec[l] *= (xd[col_idx[j]] - xd[col_idx[j]-k-1]) / (k+1);
-			}
-			l++;
-		}
-	}
+      // Discrete integration weighting
+      if (di_weighting && col_idx[j] >= k+1) {
+        x_vec[l] *= (xd[col_idx[j]] - xd[col_idx[j]-k-1]) / (k+1);
+      }
+      l++;
+    }
+  }
 
-	return List::create(Named("i") = i_vec, Named("j") = j_vec, Named("x") = x_vec);
+  return List::create(Named("i") = i_vec, Named("j") = j_vec, Named("x") = x_vec);
 }
 
 // [[Rcpp::export]]
 List rcpp_n_mat(int k, NumericVector xd, bool normalized, IntegerVector knot_idx) {
-	// Compute number of nonzero elements for N. We do so by computing nonzeros
-	// per column (discrete B-spline basis vector)
-	int n_row = xd.size() - k - 1, n_col = knot_idx.size(), N = 0; 
-	for (int j = 0; j < n_col; j++) {
-		if (j < k+1) N += knot_idx[j] + 1; // First k+1 functions
-		else if (j < n_col-k-1) N += knot_idx[j] - knot_idx[j-k-1] + 1; 
-		else N += n_row - knot_idx[j-k-1]; // Last k+1 functions
-	}
-	
-	// Now construct N in sparse triplet format
-	IntegerVector i_vec (N);
-	IntegerVector j_vec (N);
-	NumericVector x_vec (N);
-	int l = 0, l_last;
-	for (int j = 0; j < n_col; j++) {
-		l_last = l; // Save this in case we need it later for the normalization
+  // Compute number of nonzero elements for N. We do so by computing nonzeros
+  // per column (discrete B-spline basis vector)
+  int n_row = xd.size() - k - 1, n_col = knot_idx.size(), N = 0;
+  for (int j = 0; j < n_col; j++) {
+    if (j < k+1) N += knot_idx[j] + 1; // First k+1 functions
+    else if (j < n_col-k-1) N += knot_idx[j] - knot_idx[j-k-1] + 1;
+    else N += n_row - knot_idx[j-k-1]; // Last k+1 functions
+  }
 
-		// Solve a linear system to get the appropriate basis vector N_j, store it
-		// in the triplet list, and update the counter l by reference
-		nj(k, xd, knot_idx, j, i_vec, j_vec, x_vec, l);
+  // Now construct N in sparse triplet format
+  IntegerVector i_vec (N);
+  IntegerVector j_vec (N);
+  NumericVector x_vec (N);
+  int l = 0, l_last;
+  for (int j = 0; j < n_col; j++) {
+    l_last = l; // Save this in case we need it later for the normalization
 
-		if (normalized) {
-			double max = *std::max_element(x_vec.begin() + l_last, x_vec.begin() + l);
-			for (int p = l_last; p < l; p++) x_vec[p] = x_vec[p] / max;
-		}
-	}
-	
-	return List::create(Named("i") = i_vec, Named("j") = j_vec, Named("x") = x_vec);
+    // Solve a linear system to get the appropriate basis vector N_j, store it
+    // in the triplet list, and update the counter l by reference
+    nj(k, xd, knot_idx, j, i_vec, j_vec, x_vec, l);
+
+    if (normalized) {
+      double max = *std::max_element(x_vec.begin() + l_last, x_vec.begin() + l);
+      for (int p = l_last; p < l; p++) x_vec[p] = x_vec[p] / max;
+    }
+  }
+
+  return List::create(Named("i") = i_vec, Named("j") = j_vec, Named("x") = x_vec);
 }
 
 /******************************************************************************/
@@ -113,30 +113,30 @@ List rcpp_n_mat(int k, NumericVector xd, bool normalized, IntegerVector knot_idx
 
 // [[Rcpp::export]]
 List rcpp_h_eval(int k, NumericVector xd, NumericVector x, IntegerVector col_idx) {
-	// Compute number of nonzero elements for H. We do so by computing nonzeros 
-	// per column (falling factorial basis vector). Along the way we compute the
-	// index of the smallest nonzero evaluation per column
-	int n_row = x.size(), n_col = col_idx.size(), N = n_row * n_col;
-	IntegerVector I (n_col);
-	for (int j = 0; j < n_col; j++) {
-		// Find the index of smallest nonzero query evaluation for h_j 
-		I[j] = std::upper_bound(x.begin(), x.end(), xd[col_idx[j]-1]) - x.begin();
-		N -= I[j];
-	}
+  // Compute number of nonzero elements for H. We do so by computing nonzeros
+  // per column (falling factorial basis vector). Along the way we compute the
+  // index of the smallest nonzero evaluation per column
+  int n_row = x.size(), n_col = col_idx.size(), N = n_row * n_col;
+  IntegerVector I (n_col);
+  for (int j = 0; j < n_col; j++) {
+    // Find the index of smallest nonzero query evaluation for h_j
+    I[j] = std::upper_bound(x.begin(), x.end(), xd[col_idx[j]-1]) - x.begin();
+    N -= I[j];
+  }
 
-	// Now construct H in sparse triplet format
-	IntegerVector i_vec (N);
-	IntegerVector j_vec (N);
-	NumericVector x_vec (N);
-	int l = 0;
-	for (int j = 0; j < n_col; j++) {
-		for (int i = I[j]; i < n_row; i++) {
-			i_vec[l] = i;
-			j_vec[l] = j;
-			x_vec[l] = hxj(k, xd, x[i], col_idx[j]);
-			l++;
-		}
-	}
+  // Now construct H in sparse triplet format
+  IntegerVector i_vec (N);
+  IntegerVector j_vec (N);
+  NumericVector x_vec (N);
+  int l = 0;
+  for (int j = 0; j < n_col; j++) {
+    for (int i = I[j]; i < n_row; i++) {
+      i_vec[l] = i;
+      j_vec[l] = j;
+      x_vec[l] = hxj(k, xd, x[i], col_idx[j]);
+      l++;
+    }
+  }
 
-	return List::create(Named("i") = i_vec, Named("j") = j_vec, Named("x") = x_vec);
+  return List::create(Named("i") = i_vec, Named("j") = j_vec, Named("x") = x_vec);
 }

--- a/src/matrix_multiplication.cpp
+++ b/src/matrix_multiplication.cpp
@@ -3,99 +3,99 @@
 
 #include <Rcpp.h>
 #include "dspline.h"
-using namespace Rcpp; 
+using namespace Rcpp;
 
 // [[Rcpp::export]]
 void rcpp_dot_b_mat_mult(NumericVector v, int k, NumericVector xd, bool tf_weighting, bool transpose, bool inverse) {
-	if (!transpose && !inverse) {
-		for (int i = 1; i <= k; i++) {
-			Diff(v, i);
-			InvGapWeight(v, i, xd); 
-		}		
-		if (tf_weighting) GapWeight(v, k, xd); 
-	}
-	else if (transpose && !inverse) {
-		if (tf_weighting) GapWeight(v, k, xd); 
-		for (int i = k; i >= 1; i--) {
-			InvGapWeight(v, i, xd); 
-			RevDiff(v, i-1);
-		}
-	}
-	else if (!transpose && inverse) {
-		if (tf_weighting) InvGapWeight(v, k, xd); 
-		for (int i = k; i >= 1; i--) {
-			GapWeight(v, i, xd);
-			CumSum(v, i-1);
-		}
-	}
-	else {
-		for (int i = 1; i <= k; i++) {
-			RevCumSum(v, i-1);
-			GapWeight(v, i, xd); 
-		}
-		if (tf_weighting) InvGapWeight(v, k, xd); 
-	}
+  if (!transpose && !inverse) {
+    for (int i = 1; i <= k; i++) {
+      Diff(v, i);
+      InvGapWeight(v, i, xd);
+    }
+    if (tf_weighting) GapWeight(v, k, xd);
+  }
+  else if (transpose && !inverse) {
+    if (tf_weighting) GapWeight(v, k, xd);
+    for (int i = k; i >= 1; i--) {
+      InvGapWeight(v, i, xd);
+      RevDiff(v, i-1);
+    }
+  }
+  else if (!transpose && inverse) {
+    if (tf_weighting) InvGapWeight(v, k, xd);
+    for (int i = k; i >= 1; i--) {
+      GapWeight(v, i, xd);
+      CumSum(v, i-1);
+    }
+  }
+  else {
+    for (int i = 1; i <= k; i++) {
+      RevCumSum(v, i-1);
+      GapWeight(v, i, xd);
+    }
+    if (tf_weighting) InvGapWeight(v, k, xd);
+  }
 }
 
 // [[Rcpp::export]]
 void rcpp_dot_h_mat_mult(NumericVector v, int k, NumericVector xd, bool di_weighting, bool transpose, bool inverse) {
-	if (!transpose && !inverse) {
-		if (di_weighting) GapWeight(v, k+1, xd); 
-		for (int i = k; i >= 0; i--) {
-			CumSum(v, i);
-			if (i != 0) GapWeight(v, i, xd); 
-		}
-	}
-	else if (transpose && !inverse) {
-		for (int i = 0; i <= k; i++) {
-			if (i != 0) GapWeight(v, i, xd); 
-			RevCumSum(v, i);
-		}
-		if (di_weighting) GapWeight(v, k+1, xd); 
-	}
-	else if (!transpose && inverse) {
-		for (int i = 0; i <= k; i++) {
-			if (i != 0) InvGapWeight(v, i, xd); 
-			Diff(v, i+1);
-		}
-		if (di_weighting) InvGapWeight(v, k+1, xd); 
-	}
-	else {
-		if (di_weighting) InvGapWeight(v, k+1, xd); 
-		for (int i = k; i >= 0; i--) {
-			RevDiff(v, i);
-			if (i != 0) InvGapWeight(v, i, xd); 
-		}
-	}
+  if (!transpose && !inverse) {
+    if (di_weighting) GapWeight(v, k+1, xd);
+    for (int i = k; i >= 0; i--) {
+      CumSum(v, i);
+      if (i != 0) GapWeight(v, i, xd);
+    }
+  }
+  else if (transpose && !inverse) {
+    for (int i = 0; i <= k; i++) {
+      if (i != 0) GapWeight(v, i, xd);
+      RevCumSum(v, i);
+    }
+    if (di_weighting) GapWeight(v, k+1, xd);
+  }
+  else if (!transpose && inverse) {
+    for (int i = 0; i <= k; i++) {
+      if (i != 0) InvGapWeight(v, i, xd);
+      Diff(v, i+1);
+    }
+    if (di_weighting) InvGapWeight(v, k+1, xd);
+  }
+  else {
+    if (di_weighting) InvGapWeight(v, k+1, xd);
+    for (int i = k; i >= 0; i--) {
+      RevDiff(v, i);
+      if (i != 0) InvGapWeight(v, i, xd);
+    }
+  }
 }
 
 // [[Rcpp::export]]
 NumericVector rcpp_d_mat_mult(NumericVector v, int k, NumericVector xd, bool tf_weighting, bool transpose) {
-	if (!transpose) {
-		NumericVector v_copy = clone(v);
-		rcpp_dot_b_mat_mult(v_copy, k, xd, tf_weighting, transpose, 0);
-		return v_copy[Range(k, v_copy.size()-1)];
-	}
-	else {
-		int n = v.size() + k;
-		NumericVector v_copy (n); 
-		for (int i = 0; i < k; i++) v_copy[i] = 0;
-		for (int i = k; i < n; i++) v_copy[i] = v[i-k];
-		rcpp_dot_b_mat_mult(v_copy, k, xd, tf_weighting, transpose, 0);
-		return v_copy;
-	}
+  if (!transpose) {
+    NumericVector v_copy = clone(v);
+    rcpp_dot_b_mat_mult(v_copy, k, xd, tf_weighting, transpose, 0);
+    return v_copy[Range(k, v_copy.size()-1)];
+  }
+  else {
+    int n = v.size() + k;
+    NumericVector v_copy (n);
+    for (int i = 0; i < k; i++) v_copy[i] = 0;
+    for (int i = k; i < n; i++) v_copy[i] = v[i-k];
+    rcpp_dot_b_mat_mult(v_copy, k, xd, tf_weighting, transpose, 0);
+    return v_copy;
+  }
 }
 
 // [[Rcpp::export]]
 NumericVector rcpp_b_mat_mult(NumericVector v, int k, NumericVector xd, bool tf_weighting, bool transpose, bool inverse) {
-	NumericVector v_copy = clone(v);
-	rcpp_dot_b_mat_mult(v_copy, k, xd, tf_weighting, transpose, inverse);
-	return v_copy;
+  NumericVector v_copy = clone(v);
+  rcpp_dot_b_mat_mult(v_copy, k, xd, tf_weighting, transpose, inverse);
+  return v_copy;
 }
 
 // [[Rcpp::export]]
 NumericVector rcpp_h_mat_mult(NumericVector v, int k, NumericVector xd, bool di_weighting, bool transpose, bool inverse) {
-	NumericVector v_copy = clone(v);
-	rcpp_dot_h_mat_mult(v_copy, k, xd, di_weighting, transpose, inverse);
-	return v_copy;
+  NumericVector v_copy = clone(v);
+  rcpp_dot_h_mat_mult(v_copy, k, xd, di_weighting, transpose, inverse);
+  return v_copy;
 }

--- a/src/note.cpp
+++ b/src/note.cpp
@@ -3,16 +3,16 @@
 
 // It looks like NumericVector objects (and other vector/matrix objects) are
 // always be passed reference. To check this, uncomment the functions below,
-// recompile, and then run the following in R. >>> a = rnorm(5); foo(a); a 
+// recompile, and then run the following in R. >>> a = rnorm(5); foo(a); a
 
 // #include <Rcpp.h>
-// using namespace Rcpp; 
+// using namespace Rcpp;
 
 // void bar(NumericVector a) {
-// 	a[0] = 5;
+//   a[0] = 5;
 // }
 
 // // [[Rcpp::export]]
 // void foo(NumericVector a) {
-// 	bar(a);
+//   bar(a);
 // }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,53 +2,53 @@
 // Simple utilities
 
 #include <Rcpp.h>
-using namespace Rcpp; 
+using namespace Rcpp;
 
-// Factorial 
+// Factorial
 int fact(int k) {
-	int a = 1;
-	for (int i = 1; i <= k; i++) a *= i;
-	return a; 
+  int a = 1;
+  for (int i = 1; i <= k; i++) a *= i;
+  return a;
 }
 
 // Overwrite v with cumulative sums, starting at i
 void CumSum(NumericVector v, int i) {
-	for (int j = i+1; j < v.size(); j++) {
-		v[j] += v[j-1];
-	}
+  for (int j = i+1; j < v.size(); j++) {
+    v[j] += v[j-1];
+  }
 }
 
 // Overwrite v with reverse cumulative sums, ending at i
 void RevCumSum(NumericVector v, int i) {
-	for (int j = v.size()-2; j >= i; j--) {
-		v[j] += v[j+1];
-	}
+  for (int j = v.size()-2; j >= i; j--) {
+    v[j] += v[j+1];
+  }
 }
 
 // Overwrite v with pairwise differences, starting at i
 void Diff(NumericVector v, int i) {
-	for (int j = v.size()-1; j >= i; j--) {
-		v[j] -= v[j-1];
-	}
+  for (int j = v.size()-1; j >= i; j--) {
+    v[j] -= v[j-1];
+  }
 }
 
 // Overwrite v with reverse pairwise differences, ending at i
 void RevDiff(NumericVector v, int i) {
-	for (int j = i; j < v.size()-1; j++) {
-		v[j] -= v[j+1];
-	}
+  for (int j = i; j < v.size()-1; j++) {
+    v[j] -= v[j+1];
+  }
 }
 
 // Apply gap weighting to v (wrt xd), starting at i
 void GapWeight(NumericVector v, int i, NumericVector xd) {
-	for (int j = i; j < v.size(); j++) {
-		v[j] *= (xd[j] - xd[j-i]) / i;
-	}		
+  for (int j = i; j < v.size(); j++) {
+    v[j] *= (xd[j] - xd[j-i]) / i;
+  }
 }
 
 // Apply invesre gap weighting to v (wrt xd), starting at i
 void InvGapWeight(NumericVector v, int i, NumericVector xd) {
-	for (int j = i; j < v.size(); j++) {
-		v[j] /= (xd[j] - xd[j-i]) / i;
-	}		
+  for (int j = i; j < v.size(); j++) {
+    v[j] /= (xd[j] - xd[j-i]) / i;
+  }
 }


### PR DESCRIPTION
The current behavior of `h_eval` is to only evaluate entries
where the newx point is greater than the knot `t_k` for the kth
basis function.  This makes sense for the FF basis functions,
but the polynomial basis functions are nonzero for `x < t_k`
(except at the design points, which are roots).

Will merge this after merging #2 