### PR TITLE
Evaluate all entries for polynomial basis functions in h_eval

### DIFF
--- a/src/matrix_construction.cpp
+++ b/src/matrix_construction.cpp
@@ -119,8 +119,13 @@ List rcpp_h_eval(int k, NumericVector xd, NumericVector x, IntegerVector col_idx
   int n_row = x.size(), n_col = col_idx.size(), N = n_row * n_col;
   IntegerVector I (n_col);
   for (int j = 0; j < n_col; j++) {
-    // Find the index of smallest nonzero query evaluation for h_j
-    I[j] = std::upper_bound(x.begin(), x.end(), xd[col_idx[j]-1]) - x.begin();
+    if (col_idx[j] < k+1) {
+      // Evaluate all entries for polynomial basis functions
+      I[j] = 0;
+    } else {
+      // Find the index of smallest nonzero query evaluation for h_j
+      I[j] = std::upper_bound(x.begin(), x.end(), xd[col_idx[j]-1]) - x.begin();
+    }
     N -= I[j];
   }
 

--- a/tests/testthat/test-dspline.R
+++ b/tests/testthat/test-dspline.R
@@ -256,7 +256,7 @@ test_that("Construct N matrix", {
 test_that("Evaluate H basis", {
   n = 10
   k = 2
-  col_idx = sample((k+2):n, 4)
+  col_idx = c(sample(1:(k+1), 2), sample((k+2):n, 4))
   xd = sort(runif(n))
   x = seq(0, 1, length=100)
   H = h_mat(k, xd, col_idx = col_idx)


### PR DESCRIPTION
The current behavior of h_eval is to only evaluate entries
where the newx point is greater than the knot t_k for the kth
basis function. This makes sense for the FF basis functions,
but the polynomial basis functions are nonzero for x < t_k
(except at the design points, which are roots).

In this commits:
- fix the behavior of `h_eval`
- amend an existing test to check for proper evaluation of polynomial terms

Before fix (with amended test case):

```
> devtools::test()
ℹ Testing dspline
✔ | F W S  OK | Context
✖ | 1      49 | dspline [0.5s]
─────────────────
Failure (test-dspline.R:275:3): Evaluate H basis
`y1` (`actual`) not equal to `y2` (`expected`).

     actual              | expected
 [1] -2.4654744612931472 - 0.0000000000000000  [1]
 [2] -2.4738201555068517 - -2.5373638362509543 [2]
 [3] -2.4821658497205603 - -2.5373638362509543 [3]
 [4] -2.4905115439342662 - -2.5373638362509543 [4]
 [5] -2.4988572381479681 - -2.5373638362509543 [5]
 [6] -2.5072029323616749 - -2.5373638362509543 [6]
 [7] -2.5155486265753804 - -2.5373638362509543 [7]
 [8] -2.5238943207890858 - -2.5373638362509543 [8]
 [9] -2.5322400150027908 - -2.5373638362509543 [9]
[10] -2.5405857092164963 - -2.5405857092164954 [10]
 ... ...                   ...                 and 90 more ...

══ Results ══════════
Duration: 0.5 s

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 49 ]
```

After fix:

```
> devtools::test()
ℹ Testing dspline
✔ | F W S  OK | Context
✔ |        50 | dspline [0.5s]

══ Results ══════════════
Duration: 0.5 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 50 ]
```

(Closed a previous PR and opened this one because I messed up
a part of the git workflow previously 😅)