### PR TITLE
Fix `n_eval` when `is.null(N)`

### DIFF
--- a/R/matrix_evaluation.R
+++ b/R/matrix_evaluation.R
@@ -56,7 +56,7 @@ h_eval <- function(k, xd, x, col_idx = NULL) {
 #'   default is `NULL`, which is taken to mean `(k+1):(n-1)`.
 #' @param N Matrix of discrete B-spline evaluations at the design points. The
 #'   default is `NULL`, which means that this is precomputed before constructing
-#'   the matrix of discrete B-spline evaluations at the query points. If `Nd` is
+#'   the matrix of discrete B-spline evaluations at the query points. If `N` is
 #'   non-`NULL`, then the argument `normalized` will be ignored (as this would
 #'   have only been used to construct N at the design points).
 #' @return Sparse matrix of dimension `length(x)` by `length(knot_idx) + k + 1`.
@@ -75,9 +75,9 @@ h_eval <- function(k, xd, x, col_idx = NULL) {
 #' Unlike the falling factorial basis, the discrete B-spline basis is not
 #'   generally available in closed-form. Therefore, the current function (unlike
 #'   [h_eval()]) will first check if it should precompute the evaluations of the
-#'   discrete B-spline basis at the design points. If the argument `Nd` is
+#'   discrete B-spline basis at the design points. If the argument `N` is
 #'   non-`NULL`, then it will use this as the matrix of evaluations at the
-#'   design points; if `Nd` is `NULL`, then it will call [n_mat()] to produce
+#'   design points; if `N` is `NULL`, then it will call [n_mat()] to produce
 #'   such a matrix, and will pass to this function the arguments `normalized`
 #'   and `knot_idx` accordingly.
 #'

--- a/R/matrix_evaluation.R
+++ b/R/matrix_evaluation.R
@@ -90,7 +90,7 @@ h_eval <- function(k, xd, x, col_idx = NULL) {
 #' @export
 n_eval <- function(k, xd, x, normalized = TRUE, knot_idx = NULL, N = NULL) {
   if (is.null(N)) {
-    N = n_mat(x, xd, normalized, knot_idx)
+    N = n_mat(k, xd, normalized, knot_idx)
   }
   else {
     check_nonneg_int(k)

--- a/man/n_eval.Rd
+++ b/man/n_eval.Rd
@@ -23,7 +23,7 @@ default is \code{NULL}, which is taken to mean \code{(k+1):(n-1)}.}
 
 \item{N}{Matrix of discrete B-spline evaluations at the design points. The
 default is \code{NULL}, which means that this is precomputed before constructing
-the matrix of discrete B-spline evaluations at the query points. If \code{Nd} is
+the matrix of discrete B-spline evaluations at the query points. If \code{N} is
 non-\code{NULL}, then the argument \code{normalized} will be ignored (as this would
 have only been used to construct N at the design points).}
 }
@@ -49,9 +49,9 @@ matrix has a corresponding row with entries:
 Unlike the falling factorial basis, the discrete B-spline basis is not
 generally available in closed-form. Therefore, the current function (unlike
 \code{\link[=h_eval]{h_eval()}}) will first check if it should precompute the evaluations of the
-discrete B-spline basis at the design points. If the argument \code{Nd} is
+discrete B-spline basis at the design points. If the argument \code{N} is
 non-\code{NULL}, then it will use this as the matrix of evaluations at the
-design points; if \code{Nd} is \code{NULL}, then it will call \code{\link[=n_mat]{n_mat()}} to produce
+design points; if \code{N} is \code{NULL}, then it will call \code{\link[=n_mat]{n_mat()}} to produce
 such a matrix, and will pass to this function the arguments \code{normalized}
 and \code{knot_idx} accordingly.
 

--- a/tests/testthat/test-dspline.R
+++ b/tests/testthat/test-dspline.R
@@ -276,11 +276,14 @@ test_that("Evaluate N basis", {
   xd = sort(runif(n))
   x = seq(0, 1, length=100)
 
-  N1 = n_mat(k, xd, knot_idx = knot_idx)
-  N2 = as.matrix(n_eval(k, xd, x, knot_idx = knot_idx, N = N1))
-  N3 = matrix(0, length(x), ncol(N2))
-  for (j in 1:ncol(N3)) N3[,j] = dspline_interp(N1[,j], k, xd, x)
-  expect_equal(N2, N3, tolerance = tol, ignore_attr = TRUE)
+  # n_mat already tested against dbs.evals.sk previously
+  N_xd = n_mat(k, xd, knot_idx = knot_idx)
+  N_x0 = as.matrix(n_eval(k, xd, x, knot_idx = knot_idx))
+  N_x1 = as.matrix(n_eval(k, xd, x, knot_idx = knot_idx, N = N_xd))
+  N_x2 = matrix(0, length(x), ncol(N_x1))
+  for (j in 1:ncol(N_x2)) N_x2[,j] = dspline_interp(N_xd[,j], k, xd, x)
+  expect_equal(N_x0, N_x1, tolerance = tol, ignore_attr = TRUE)
+  expect_equal(N_x0, N_x2, tolerance = tol, ignore_attr = TRUE)
 })
 
 test_that("Projection", {


### PR DESCRIPTION
Fixes a single-character bug in `n_eval`.

- Make test cases more robust.
- Fix bug.
- Update documentation (unrelated typo for same function).

Before fix (with more robust tests in bcfd5ab):
```
> devtools::test()
ℹ Testing dspline
✔ | F W S  OK | Context
✖ | 1 2    49 | dspline [0.6s]
─────────────────────────────────────────────────────────────────────────────────────────────────
Warning (test-dspline.R:281:3): Evaluate N basis
'length(x) = 100 > 1' in coercion to 'logical(1)'
Backtrace:
 1. base::as.matrix(n_eval(k, xd, x, knot_idx = knot_idx))
      at test-dspline.R:281:2
 2. dspline::n_eval(k, xd, x, knot_idx = knot_idx)
 3. dspline::n_mat(x, xd, normalized, knot_idx)
      at my-dspline/R/matrix_evaluation.R:94:4
 4. dspline:::check_nonneg_int(k)
      at my-dspline/R/matrix_construction.R:329:2

Warning (test-dspline.R:281:3): Evaluate N basis
'length(x) = 100 > 1' in coercion to 'logical(1)'
Backtrace:
 1. base::as.matrix(n_eval(k, xd, x, knot_idx = knot_idx))
      at test-dspline.R:281:2
 2. dspline::n_eval(k, xd, x, knot_idx = knot_idx)
 3. dspline::n_mat(x, xd, normalized, knot_idx)
      at my-dspline/R/matrix_evaluation.R:94:4
 4. dspline:::check_nonneg_int(k)
      at my-dspline/R/matrix_construction.R:329:2

Error (test-dspline.R:281:3): Evaluate N basis
Error in `if (length(x) < n) {
    rlang::abort(sprintf("`length(%s)` must be at least `%s`.",
        args[1], args[2]))
}`: the condition has length > 1
Backtrace:
 1. base::as.matrix(n_eval(k, xd, x, knot_idx = knot_idx))
      at test-dspline.R:281:2
 2. dspline::n_eval(k, xd, x, knot_idx = knot_idx)
 3. dspline::n_mat(x, xd, normalized, knot_idx)
      at my-dspline/R/matrix_evaluation.R:94:4
 4. dspline:::check_length(xd, k + 1, ">=")
      at my-dspline/R/matrix_construction.R:330:2
─────────────────────────────────────────────────────────────────────────────────────────────────

══ Results ══════════════════════════════════════════════════════════════════════════════════════
Duration: 0.6 s

[ FAIL 1 | WARN 2 | SKIP 0 | PASS 49 ]
```

After fix:

```
> devtools::test()
ℹ Testing dspline
✔ | F W S  OK | Context
✔ |        51 | dspline [0.2s]

══ Results ══════════════════════════════════════════════════════════════════════════════════════
Duration: 0.2 s

[ FAIL 0 | WARN 0 | SKIP 0 | PASS 51 ]
```

Resolves #6 