### PR TITLE
Use function templates to accommodate other vector types

### DIFF
--- a/src/dspline.h
+++ b/src/dspline.h
@@ -8,12 +8,18 @@ using namespace Rcpp;
 // Simple utilities
 
 int fact(int k);
-void CumSum(NumericVector v, int i);
-void RevCumSum(NumericVector v, int i);
-void Diff(NumericVector v, int i);
-void RevDiff(NumericVector v, int i);
-void GapWeight(NumericVector v, int i, NumericVector xd);
-void InvGapWeight(NumericVector v, int i, NumericVector xd);
+template<typename T>
+void CumSum(T& v, int i);
+template<typename T>
+void RevCumSum(T& v, int i);
+template<typename T>
+void Diff(T& v, int i);
+template<typename T>
+void RevDiff(T& v, int i);
+template<typename T, typename U>
+void GapWeight(T& v, int i, U& xd);
+template<typename T, typename U>
+void InvGapWeight(T& v, int i, U& xd);
 
 /******************************************************************************/
 // Divided differences, discrete derivatives, and discrete integrals 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -2,6 +2,8 @@
 // Simple utilities
 
 #include <Rcpp.h>
+#include <RcppEigen.h>
+#include <Eigen/Sparse>
 using namespace Rcpp;
 
 // Factorial
@@ -12,43 +14,65 @@ int fact(int k) {
 }
 
 // Overwrite v with cumulative sums, starting at i
-void CumSum(NumericVector v, int i) {
+template<typename T>
+void CumSum(T& v, int i) {
   for (int j = i+1; j < v.size(); j++) {
     v[j] += v[j-1];
   }
 }
+template void CumSum<NumericVector>(NumericVector& v, int i);
+template void CumSum<Eigen::VectorXd>(Eigen::VectorXd& v, int i);
 
 // Overwrite v with reverse cumulative sums, ending at i
-void RevCumSum(NumericVector v, int i) {
+template<typename T>
+void RevCumSum(T& v, int i) {
   for (int j = v.size()-2; j >= i; j--) {
     v[j] += v[j+1];
   }
 }
+template void RevCumSum<NumericVector>(NumericVector& v, int i);
+template void RevCumSum<Eigen::VectorXd>(Eigen::VectorXd& v, int i);
 
 // Overwrite v with pairwise differences, starting at i
-void Diff(NumericVector v, int i) {
+template<typename T>
+void Diff(T& v, int i) {
   for (int j = v.size()-1; j >= i; j--) {
     v[j] -= v[j-1];
   }
 }
+template void Diff<NumericVector>(NumericVector& v, int i);
+template void Diff<Eigen::VectorXd>(Eigen::VectorXd& v, int i);
 
 // Overwrite v with reverse pairwise differences, ending at i
-void RevDiff(NumericVector v, int i) {
+template<typename T>
+void RevDiff(T& v, int i) {
   for (int j = i; j < v.size()-1; j++) {
     v[j] -= v[j+1];
   }
 }
+template void RevDiff<NumericVector>(NumericVector& v, int i);
+template void RevDiff<Eigen::VectorXd>(Eigen::VectorXd& v, int i);
 
 // Apply gap weighting to v (wrt xd), starting at i
-void GapWeight(NumericVector v, int i, NumericVector xd) {
+template<typename T, typename U>
+void GapWeight(T& v, int i, U& xd) {
   for (int j = i; j < v.size(); j++) {
     v[j] *= (xd[j] - xd[j-i]) / i;
   }
 }
+template void GapWeight<NumericVector,NumericVector>(NumericVector& v, int i, NumericVector& xd);
+template void GapWeight<NumericVector,Eigen::VectorXd>(NumericVector& v, int i, Eigen::VectorXd& xd);
+template void GapWeight<Eigen::VectorXd,NumericVector>(Eigen::VectorXd& v, int i, NumericVector& xd);
+template void GapWeight<Eigen::VectorXd,Eigen::VectorXd>(Eigen::VectorXd& v, int i, Eigen::VectorXd& xd);
 
 // Apply invesre gap weighting to v (wrt xd), starting at i
-void InvGapWeight(NumericVector v, int i, NumericVector xd) {
+template<typename T, typename U>
+void InvGapWeight(T& v, int i, U& xd) {
   for (int j = i; j < v.size(); j++) {
     v[j] /= (xd[j] - xd[j-i]) / i;
   }
 }
+template void InvGapWeight<NumericVector,NumericVector>(NumericVector& v, int i, NumericVector& xd);
+template void InvGapWeight<NumericVector,Eigen::VectorXd>(NumericVector& v, int i, Eigen::VectorXd& xd);
+template void InvGapWeight<Eigen::VectorXd,NumericVector>(Eigen::VectorXd& v, int i, NumericVector& xd);
+template void InvGapWeight<Eigen::VectorXd,Eigen::VectorXd>(Eigen::VectorXd& v, int i, Eigen::VectorXd& xd);


### PR DESCRIPTION
`dspline` makes generous use of Rcpp Vector classes.  Rcpp classes make sense when interfacing with directly with R code, but the use of Rcpp classes to represent vectors in internal, lower-level routines (e.g., [evaluation of basis vectors](https://github.com/ryantibs/dspline/blob/main/src/bases_weights.cpp)) offers comparatively little advantage.  Those functions do not use features unique to Rcpp classes (Rcpp sugar, attributes), nor methods implemented exclusively for Rcpp classes.  

At the same time, another package may want to link to `dspline` code for its efficient implementations of matrix construction, (in-place) multiplication, etc.  That package might also be representing most of its internal objects using Eigen::VectorXd for numerical computation, and may want to avoid copying Eigen::VectorXd objects into Rcpp objects just to call `dspline` routines.

[Function templates](https://isocpp.org/wiki/faq/templates#fn-templates) allow us to generalize a single function definition to accommodate different object types.  The functions in [utils.cpp](https://github.com/ryantibs/dspline/blob/main/src/utils.cpp) would be implemented the same way whether it were using `Eigen::VectorXd` or `stl::vector<double>` in lieu of `NumericVector`.  Turning them into template functions tells the compiler to create three versions of each function.  The compiler then uses type inference to decide which version to apply (or one can [explicitly call](https://isocpp.org/wiki/faq/templates#fn-templates-explicit-calls) a version of the function).

This draft PR is an example of concept for how we could use function templates throughout Rcpp to generalize its code and make it more useful for external packages.  (A more ambitious goal is to think about which parts of `dspline` and our other packages can or should be implemented solely using, e.g., Eigen, with Rcpp[Eigen] used only to "glue" those functions to R, so that in the future we or others may be able to link to these C++ functions from other high-level languages.  Even in that code, it makes sense to accommodate Rcpp Vectors to take advantage of the proxy model of memory.  Function templates let us have the best of both worlds.)

One point of dissatisfaction I have with function templates is that separate the declaration and definition of a template function is a [messy business](https://isocpp.org/wiki/faq/templates#templates-defn-vs-decl).  In this draft PR, one can see a standard workaround for keeping the declaration in a header file and the definition in a cpp file: explicitly instantiating versions of the template function in the file where it is defined.  (The basic problem is that if a template function is defined in a separate cpp file from where it is used, say with type `int`, then those files are compiled separately and the compiler doesn't know to create a version of the template function for type `int`, resulting a link error.)